### PR TITLE
WIP: xrOS Support

### DIFF
--- a/script/build-libssh2.sh
+++ b/script/build-libssh2.sh
@@ -45,8 +45,16 @@ do
     export SDKROOT="$DEVROOT/SDKs/$PLATFORM.sdk"
     export CC="$CLANG"
     export CPP="$CLANG -E"
-    export CFLAGS="-arch $ARCH -pipe -no-cpp-precomp -isysroot $SDKROOT -m$SDK_PLATFORM-version-min=$MIN_VERSION"
-    export CPPFLAGS="-arch $ARCH -pipe -no-cpp-precomp -isysroot $SDKROOT -m$SDK_PLATFORM-version-min=$MIN_VERSION"
+
+    export CFLAGS="-arch $ARCH -pipe -no-cpp-precomp -isysroot $SDKROOT"
+    export CPPFLAGS="-arch $ARCH -pipe -no-cpp-precomp -isysroot $SDKROOT"
+
+    # TODO: XROS MIN VERSION
+    if [[ "$SDK_PLATFORM" != "xros" ]] || [[ "$SDK_PLATFORM" != "xros*" ]]; then
+      export CFLAGS="$CFLAGS -m$SDK_PLATFORM-version-min=$MIN_VERSION"
+      export CPPFLAGS="$CPPFLAGS -m$SDK_PLATFORM-version-min=$MIN_VERSION"
+    fi
+
     if [[ "$EFFECTIVE_PLATFORM_NAME" == "-maccatalyst" ]]; then
         EXTRAFLAGS="-target $ARCH-apple-ios13.1-macabi -Wno-overriding-t-option"
         CFLAGS="${CFLAGS} ${EXTRAFLAGS}"

--- a/script/build-openssl.sh
+++ b/script/build-openssl.sh
@@ -68,7 +68,12 @@ do
     export BITCODE_GENERATION_MODE=bitcode
     export CFLAGS="$CFLAGS -fembed-bitcode"
 
-    CONF="$CONF -m$SDK_PLATFORM-version-min=$MIN_VERSION"
+    CONF="$CONF"
+
+    # TODO: XROS MIN VERSION
+    if [[ "$SDK_PLATFORM" != "xros" ]] || [[ "$SDK_PLATFORM" != "xros*" ]]; then
+      CONF="$CONF -m$SDK_PLATFORM-version-min=$MIN_VERSION"
+    fi
 
     {
       # split $CONF by space into parameter list

--- a/script/build-xcframework.sh
+++ b/script/build-xcframework.sh
@@ -91,21 +91,27 @@ buildLibrary "$BUILD/macosx" "macosx" "MacOSX" "" "x86_64 arm64" "10.10"
 buildLibrary "$BUILD/maccatalyst" "macosx" "MacOSX" "-maccatalyst" "x86_64 arm64" "10.15"
 buildLibrary "$BUILD/appletvsimulator" "appletvsimulator" "AppleTVSimulator" "" "x86_64 arm64" "9.0"
 buildLibrary "$BUILD/appletvos" "appletvos" "AppleTVOS" "" "arm64" "9.0"
+buildLibrary "$BUILD/xros" "xros" "XROS" "" "arm64" "17.0"
+buildLibrary "$BUILD/xrossimulator" "xrossimulator" "XRSimulator" "" "arm64" "17.0"
 
 xcodebuild -create-xcframework \
- -library "$BUILD/macosx/lib/libssh2.a" \
- -headers "$BUILD/macosx/include" \
- -library "$BUILD/iphoneos/lib/libssh2.a" \
- -headers "$BUILD/iphoneos/include" \
- -library "$BUILD/iphonesimulator/lib/libssh2.a" \
- -headers "$BUILD/iphonesimulator/include" \
- -library "$BUILD/maccatalyst/lib/libssh2.a" \
- -headers "$BUILD/maccatalyst/include" \
- -library "$BUILD/appletvsimulator/lib/libssh2.a" \
- -headers "$BUILD/appletvsimulator/include" \
- -library "$BUILD/appletvos/lib/libssh2.a" \
- -headers "$BUILD/appletvos/include" \
- -output CSSH.xcframework
+  -library "$BUILD/macosx/lib/libssh2.a" \
+  -headers "$BUILD/macosx/include" \
+  -library "$BUILD/iphoneos/lib/libssh2.a" \
+  -headers "$BUILD/iphoneos/include" \
+  -library "$BUILD/iphonesimulator/lib/libssh2.a" \
+  -headers "$BUILD/iphonesimulator/include" \
+  -library "$BUILD/maccatalyst/lib/libssh2.a" \
+  -headers "$BUILD/maccatalyst/include" \
+  -library "$BUILD/appletvsimulator/lib/libssh2.a" \
+  -headers "$BUILD/appletvsimulator/include" \
+  -library "$BUILD/appletvos/lib/libssh2.a" \
+  -headers "$BUILD/appletvos/include" \
+  -library "$BUILD/xros/lib/libssh2.a" \
+  -headers "$BUILD/xros/include" \
+  -library "$BUILD/xrossimulator/lib/libssh2.a" \
+  -headers "$BUILD/xrossimulator/include" \
+  -output CSSH.xcframework
 
 XCODE_VER="Archive date:$DATE"
 XCODE_VER+=$'\n'

--- a/script/build-xcframework.sh
+++ b/script/build-xcframework.sh
@@ -86,10 +86,10 @@ fi
 #export MIN_VERSION=$6
 
 buildLibrary "$BUILD/iphoneos" "iphoneos" "iPhoneOS" "" "armv7 armv7s arm64" "9.0"
-buildLibrary "$BUILD/iphonesimulator" "iphonesimulator" "iPhoneSimulator" "" "x86_64 arm64" "9.0"
-buildLibrary "$BUILD/macosx" "macosx" "MacOSX" "" "x86_64 arm64" "10.10"
-buildLibrary "$BUILD/maccatalyst" "macosx" "MacOSX" "-maccatalyst" "x86_64 arm64" "10.15"
-buildLibrary "$BUILD/appletvsimulator" "appletvsimulator" "AppleTVSimulator" "" "x86_64 arm64" "9.0"
+buildLibrary "$BUILD/iphonesimulator" "iphonesimulator" "iPhoneSimulator" "" "arm64" "9.0"
+buildLibrary "$BUILD/macosx" "macosx" "MacOSX" "" "arm64" "10.10"
+buildLibrary "$BUILD/maccatalyst" "macosx" "MacOSX" "-maccatalyst" "arm64" "10.15"
+buildLibrary "$BUILD/appletvsimulator" "appletvsimulator" "AppleTVSimulator" "" "arm64" "9.0"
 buildLibrary "$BUILD/appletvos" "appletvos" "AppleTVOS" "" "arm64" "9.0"
 buildLibrary "$BUILD/xros" "xros" "XROS" "" "arm64" "17.0"
 buildLibrary "$BUILD/xrossimulator" "xrossimulator" "XRSimulator" "" "arm64" "17.0"


### PR DESCRIPTION
Added support for xrOS.

WIP:
- `-m$SDK_PLATFORM-version-min=$MIN_VERSION` is removed when compiling for xrOS, `clang` does not recognize it.
- `x86_64` was not built for the simulator, but I've found `lipo` reports simulator's binary supports it.